### PR TITLE
fix: allow dynamic with for the tile level element

### DIFF
--- a/css/bbox.css
+++ b/css/bbox.css
@@ -112,7 +112,6 @@ html, body, #map {
 .bboxllpossmall { width:200px; }
 .bboxprojpos { width:450px; }
 .bboxprojpossmall { width:250px; }
-.tilesmall { width:60px; }
 .zoomsmall { width:20px; }
 
 #map-ui-proj {


### PR DESCRIPTION
currently when reaching to more than 9 chars in the tile level element the values are hidden by the zoom box.

the tile level should be visible at all time, since it is a span, we do not need to give it a width in order to give it a dynamic width according to it's content. 

![Screen Shot 2020-07-01 at 12 13 13 PM](https://user-images.githubusercontent.com/16977587/86226416-50994f80-bb94-11ea-9b86-53394dc0c518.png)
